### PR TITLE
remove redundancy and add discord.py 2.0 in requirements.txt

### DIFF
--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -64,6 +64,7 @@ class Roles(commands.Cog):
     async def process_roles(self, interaction: discord.Interaction, roles: str, action: Coroutine[Any, Any, None]) -> List[discord.Role]:
         L = [] # List of roles added/removed
         wanted = sorted(list(set(role.strip().lower() for role in roles.split(","))))
+        allowed = self.available_roles(interaction.guild, wanted)
 
         def get_role(name: str) -> discord.Role:
             for role in interaction.guild.roles:
@@ -71,7 +72,7 @@ class Roles(commands.Cog):
                     return role
             return None
 
-        for name in wanted:
+        for name in allowed:
             try:
                 role = get_role(name)
                 if role is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # How to install:
-# pip install -U --upgrade -r requirements.txt
+# pip install --upgrade -r requirements.txt
 
 aiohttp==3.8.1
 aiosignal==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ async-timeout==4.0.2
 attrs==21.4.0
 certifi==2021.10.8
 charset-normalizer==2.0.12
+discord.py==2.0.0
 frozenlist==1.3.0
 idna==3.3
 multidict==6.0.2
@@ -14,5 +15,3 @@ Pillow==9.1.0
 requests==2.27.1
 urllib3==1.26.9
 yarl==1.7.2
-
-git+https://github.com/Rapptz/discord.py@b7e25645dc68bbb828bf1ede711d098c6b183237


### PR DESCRIPTION
`-U` and `--upgrade` do the same thing, no need to have both.

discord.py 2.0 has been released - assuming you don't want to have to keep up with bleeding edge, it's probably best to just specify that version.